### PR TITLE
PHP: Simplify UNIX time generation

### DIFF
--- a/Php/app/AppTokenPhpExample.php
+++ b/Php/app/AppTokenPhpExample.php
@@ -33,7 +33,7 @@ class AppTokenGuzzlePhpExample
     public function sendHttpRequest($request, $url)
     {
         $client = new GuzzleHttp\Client();
-        $ts = round(strtotime("now"));
+        $ts = time();
 
         $request = $request->withHeader('X-App-Token', SUMSUB_APP_TOKEN);
         $request = $request->withHeader('X-App-Access-Sig', $this->createSignature($ts, $request->getMethod(), $url, $request->getBody()));


### PR DESCRIPTION
There is not need to use `strtotime` + `round` if we could just use `time` function.

```php
var_dump(round(strtotime("now")));
var_dump(strtotime("now"));
var_dump(time());
die;

// float(1616512755)
// int(1616512755)
// int(1616512755)
```

https://www.php.net/manual/en/function.time.php

>  Returns the current time measured in the number of seconds since the Unix Epoch (January 1 1970 00:00:00 GMT). 